### PR TITLE
fix: Add return traffic rules when NAT is disabled

### DIFF
--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -160,6 +160,16 @@ func configureForwardingv4(options ForwardingOptions) error {
 			return errors.Wrap(err, "failed to set ip tables rule")
 		}
 	}
+
+	// Accept return traffic when NAT is disabled
+	if !options.NAT44 {
+		for _, allowedCIDR := range options.allowedIPv4s {
+			if err := ipt.AppendUnique("filter", "WG_ACCESS_SERVER_FORWARD", "-s", allowedCIDR, "-d", options.CIDR, "-j", "ACCEPT"); err != nil {
+				return errors.Wrap(err, "failed to set ip tables rule for return traffic")
+			}
+		}
+	}
+	
 	// And reject everything else
 	if err := ipt.AppendUnique("filter", "WG_ACCESS_SERVER_FORWARD", "-s", options.CIDR, "-j", "REJECT"); err != nil {
 		return errors.Wrap(err, "failed to set ip tables rule")
@@ -213,6 +223,16 @@ func configureForwardingv6(options ForwardingOptions) error {
 			return errors.Wrap(err, "failed to set ip tables rule")
 		}
 	}
+
+	// Accept return traffic when NAT is disabled
+	if !options.NAT66 {
+		for _, allowedCIDR := range options.allowedIPv6s {
+			if err := ipt.AppendUnique("filter", "WG_ACCESS_SERVER_FORWARD", "-s", allowedCIDR, "-d", options.CIDRv6, "-j", "ACCEPT"); err != nil {
+				return errors.Wrap(err, "failed to set ip tables rule for return traffic")
+			}
+		}
+	}
+
 	// And reject everything else
 	if err := ipt.AppendUnique("filter", "WG_ACCESS_SERVER_FORWARD", "-s", options.CIDRv6, "-j", "REJECT"); err != nil {
 		return errors.Wrap(err, "failed to set ip tables rule")


### PR DESCRIPTION
### Problem
When `WG_IPV4_NAT_ENABLED=false`, wg-access-server only creates iptables rules for outbound traffic (VPN clients → allowed networks) but not for return traffic (allowed networks → VPN clients). This causes connection timeouts as reply packets are dropped by the FORWARD chain.

### Root Cause
The `configureForwardingv4` function only creates rules with pattern:
- `-s VPN_CIDR -d ALLOWED_CIDR -j ACCEPT` (outbound traffic)

But missing:
- `-s ALLOWED_CIDR -d VPN_CIDR -j ACCEPT` (return traffic)

### Solution
When NAT is disabled, automatically create bidirectional rules for each allowed network in `WG_VPN_ALLOWED_IPS`. This ensures return traffic can flow back to VPN clients without requiring manual iptables configuration.